### PR TITLE
Updates to compile with latest Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ cgmath = "0.17.0"
 lazy_static = "1.1"
 simple_logger = "1.0.1"
 threadpool = "1.0"
-rhai = "0.9.0"
+rhai = "0.19.8"
 smallvec = "0.6.5"
 conrod = { git = "https://github.com/Litecrafty/conrod", features = ["glium", "winit"] }
 glium = { git = "https://github.com/Litecrafty/glium", features = ["icon_loading"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,5 @@ simple_logger = "1.0.1"
 threadpool = "1.0"
 rhai = "0.9.0"
 smallvec = "0.6.5"
-
-[dependencies.conrod]
-git = "https://github.com/Litecrafty/conrod"
-features = ["glium", "winit"]
-
-[dependencies.glium]
-git = "https://github.com/Litecrafty/glium"
-features = ["icon_loading"]
+conrod = { git = "https://github.com/Litecrafty/conrod", features = ["glium", "winit"] }
+glium = { git = "https://github.com/Litecrafty/glium", features = ["icon_loading"] }

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@
  - Clone the repository.
  - Download and install [Rust](https://rustup.rs/) nightly.
  - Open Minecraft 1.13 jar file using any zip extractor, and copy `assets/minecraft` to Litecraft `resources` folder, or use our Launcher in developer's mode.
- - Build and run with `cargo run`
+ - Build and run with `cargo +nightly run`
  - Profit!
 
 # 🎉 F.A.Q

--- a/src/core/camera/mod.rs
+++ b/src/core/camera/mod.rs
@@ -15,7 +15,6 @@
 
 use cgmath::prelude::*;
 use cgmath::{ortho, perspective, Deg, Euler, Matrix4, Point3, Quaternion, Vector3};
-use std::f32;
 
 const YAW: f32 = -90.0;
 const PITCH: f32 = 0.0;
@@ -106,8 +105,6 @@ impl Camera {
 
     /// Get perspective matrix
     pub fn perspective(&self) -> Matrix4<f32> {
-        use std::f32;
-
         let zfar = 1024.0;
         let znear = 1.0;
 

--- a/src/core/resource_manager/mod.rs
+++ b/src/core/resource_manager/mod.rs
@@ -85,7 +85,7 @@ impl ResourceManager {
     }
 
     /// Get and load a font file
-    pub fn font(resource: &Resource) -> Result<Font, Box<Error>> {
+    pub fn font(resource: &Resource) -> Result<Font, Box<dyn Error>> {
         use conrod::text::FontCollection;
 
         info!("Loading font file '{}'", resource);

--- a/src/core/resource_manager/resource.rs
+++ b/src/core/resource_manager/resource.rs
@@ -157,7 +157,7 @@ impl Resource {
             let mut zipfile = ZipArchive::new(zipfile)?;
 
             // Read resource from ZIP
-            let mut file = zipfile.by_name(&self.folder("assets"));
+            let file = zipfile.by_name(&self.folder("assets"));
 
             // If file exist in zip
             if let Ok(mut file) = file {

--- a/src/core/resource_manager/resource.rs
+++ b/src/core/resource_manager/resource.rs
@@ -29,7 +29,7 @@ use std::io::{Error, ErrorKind};
 use std::path::{Path, PathBuf};
 use zip::read::ZipArchive;
 
-type Result<T> = std::result::Result<T, Box<error::Error>>;
+type Result<T> = std::result::Result<T, Box<dyn error::Error>>;
 
 #[derive(PartialEq, Eq, Hash)]
 /// Represents a resource URI and allows loading resource data

--- a/src/core/resource_manager/shader_manager.rs
+++ b/src/core/resource_manager/shader_manager.rs
@@ -22,7 +22,7 @@ use glium::Program;
 use std::collections::HashMap;
 use std::error::Error;
 
-type Result<T> = std::result::Result<T, Box<Error>>;
+type Result<T> = std::result::Result<T, Box<dyn Error>>;
 
 pub struct ShaderManager {
     shaders: HashMap<&'static str, Program>,

--- a/src/gfx/canvas.rs
+++ b/src/gfx/canvas.rs
@@ -81,7 +81,7 @@ impl Canvas {
         let resource_manager = ResourceManager::new(&display, &settings);
 
         // Create default scene
-        let mut scene: Box<Scene> = Box::new(LoadingScene::new());
+        let mut scene: Box<dyn Scene> = Box::new(LoadingScene::new());
 
         info!("Starting script engine!");
 

--- a/src/gfx/scene.rs
+++ b/src/gfx/scene.rs
@@ -18,7 +18,7 @@ use glium::Frame;
 
 pub enum SceneAction {
     None,
-    ChangeScene(Box<Scene>),
+    ChangeScene(Box<dyn Scene>),
     Quit,
 }
 

--- a/src/gfx/shapes.rs
+++ b/src/gfx/shapes.rs
@@ -42,7 +42,7 @@ pub struct Shapes {
 }
 
 impl Shapes {
-    pub fn new(display: &Display) -> Result<Shapes, Box<Error>> {
+    pub fn new(display: &Display) -> Result<Shapes, Box<dyn Error>> {
         Ok(Shapes {
             quad: {
                 (


### PR DESCRIPTION

**Summary 🤔**

Misc fixes to get Litecraft compiling again. It builds though there are several warnings:

```
warning: trait objects without an explicit `dyn` are deprecated
  --> src/core/resource_manager/resource.rs:32:45
   |
32 | type Result<T> = std::result::Result<T, Box<error::Error>>;
   |                                             ^^^^^^^^^^^^ help: use `dyn`: `dyn error::Error`
   |
   = note: `#[warn(bare_trait_objects)]` on by default

warning: trait objects without an explicit `dyn` are deprecated
  --> src/core/resource_manager/shader_manager.rs:25:45
   |
25 | type Result<T> = std::result::Result<T, Box<Error>>;
   |                                             ^^^^^ help: use `dyn`: `dyn Error`

warning: trait objects without an explicit `dyn` are deprecated
  --> src/core/resource_manager/mod.rs:88:58
   |
88 |     pub fn font(resource: &Resource) -> Result<Font, Box<Error>> {
   |                                                          ^^^^^ help: use `dyn`: `dyn Error`

warning: trait objects without an explicit `dyn` are deprecated
  --> src/gfx/canvas.rs:84:28
   |
84 |         let mut scene: Box<Scene> = Box::new(LoadingScene::new());
   |                            ^^^^^ help: use `dyn`: `dyn Scene`

warning: trait objects without an explicit `dyn` are deprecated
  --> src/gfx/scene.rs:21:21
   |
21 |     ChangeScene(Box<Scene>),
   |                     ^^^^^ help: use `dyn`: `dyn Scene`

warning: trait objects without an explicit `dyn` are deprecated
  --> src/gfx/shapes.rs:45:57
   |
45 |     pub fn new(display: &Display) -> Result<Shapes, Box<Error>> {
   |                                                         ^^^^^ help: use `dyn`: `dyn Error`

warning: use of deprecated function `std::mem::uninitialized`: use `mem::MaybeUninit` instead
   --> src/gfx/shapes.rs:166:1
    |
166 | implement_vertex!(Vertex3D, position, tex_coords, texture);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

warning: use of deprecated function `std::mem::uninitialized`: use `mem::MaybeUninit` instead
   --> src/gfx/shapes.rs:166:1
    |
166 | implement_vertex!(Vertex3D, position, tex_coords, texture);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

warning: use of deprecated function `std::mem::uninitialized`: use `mem::MaybeUninit` instead
   --> src/gfx/shapes.rs:167:1
    |
167 | implement_vertex!(Vertex2D, position, tex_coords);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

warning: variable does not need to be mutable
   --> src/core/resource_manager/resource.rs:160:17
    |
160 |             let mut file = zipfile.by_name(&self.folder("assets"));
    |                 ----^^^^
    |                 |
    |                 help: remove this `mut`
    |
    = note: `#[warn(unused_mut)]` on by default
```

**Test plan (required) 😏**

Tested with `cargo +nightly run`, with rustc 1.50.0-nightly. The application begins to load:

<img width="1336" alt="Screen Shot 2020-12-28 at 1 32 32 PM" src="https://user-images.githubusercontent.com/43691553/103244405-bed78880-4911-11eb-97b8-cfeae3a9d25a.png">

although it soon crashes:

```
warning: 10 warnings emitted

    Finished dev [unoptimized + debuginfo] target(s) in 0.23s
     Running `target/debug/litecraft`

  _    _ _                    __ _   
 | |  (_) |_ ___ __ _ _ __ _ / _| |_ 
 | |__| |  _/ -_) _| '_/ _` |  _|  _|
 |____|_|\__\___\__|_| \__,_|_|  \__|

2020-12-28 13:37:32 INFO  [litecraft] Starting Litecraft A1 for Minecraft 1.13.1...
2020-12-28 13:37:32 INFO  [litecraft::core::resource_manager] Loading font file '[litecraft:font:default]'
2020-12-28 13:37:32 INFO  [litecraft::core::resource_manager::texture_manager] Starting texture manager...
2020-12-28 13:37:32 INFO  [litecraft::core::resource_manager::shader_manager] Starting shader manager...
2020-12-28 13:37:32 INFO  [litecraft::gfx::canvas] Starting script engine!
2020-12-28 13:37:32 INFO  [litecraft::core::resource_manager::texture_manager] Loading texture '[litecraft:texture:logo]'.
2020-12-28 13:37:32 INFO  [litecraft::core::resource_manager::shader_manager] Loaded shader 'noise'
2020-12-28 13:37:32 INFO  [litecraft::core::resource_manager::shader_manager] Loaded shader 'quad'
2020-12-28 13:37:32 INFO  [litecraft::core::resource_manager::shader_manager] Loaded shader 'wallpaper'
2020-12-28 13:37:32 INFO  [litecraft::core::resource_manager::shader_manager] Loaded shader 'logo'
2020-12-28 13:37:32 INFO  [litecraft::core::resource_manager::texture_manager] Loading texture '[minecraft:texture:panorama_0]'.
2020-12-28 13:37:32 INFO  [litecraft::core::resource_manager::texture_manager] Loading texture '[minecraft:texture:panorama_4]'.
2020-12-28 13:37:32 INFO  [litecraft::core::resource_manager::texture_manager] Loading texture '[minecraft:texture:panorama_5]'.
2020-12-28 13:37:32 INFO  [litecraft::core::resource_manager::texture_manager] Loading texture '[minecraft:texture:panorama_1]'.
2020-12-28 13:37:32 INFO  [litecraft::core::resource_manager::texture_manager] Loading texture '[minecraft:texture:panorama_3]'.
2020-12-28 13:37:32 INFO  [litecraft::core::resource_manager::texture_manager] Loading texture '[minecraft:texture:panorama_2]'.
2020-12-28 13:37:33 DEBUG [litecraft::core::resource_manager::texture_manager] Uploading texture [litecraft:texture:logo] to GPU
2020-12-28 13:37:33 DEBUG [litecraft::core::resource_manager::texture_manager] Loaded texture [litecraft:texture:logo]
2020-12-28 13:37:34 DEBUG [litecraft::core::resource_manager::texture_manager] Uploading texture [minecraft:texture:panorama_4] to GPU
2020-12-28 13:37:34 DEBUG [litecraft::core::resource_manager::texture_manager] Loaded texture [minecraft:texture:panorama_4]
2020-12-28 13:37:34 DEBUG [litecraft::core::resource_manager::texture_manager] Uploading texture [minecraft:texture:panorama_3] to GPU
2020-12-28 13:37:34 DEBUG [litecraft::core::resource_manager::texture_manager] Loaded texture [minecraft:texture:panorama_3]
2020-12-28 13:37:34 DEBUG [litecraft::core::resource_manager::texture_manager] Uploading texture [minecraft:texture:panorama_0] to GPU
2020-12-28 13:37:34 DEBUG [litecraft::core::resource_manager::texture_manager] Loaded texture [minecraft:texture:panorama_0]
2020-12-28 13:37:34 DEBUG [litecraft::core::resource_manager::texture_manager] Uploading texture [minecraft:texture:panorama_2] to GPU
2020-12-28 13:37:34 DEBUG [litecraft::core::resource_manager::texture_manager] Loaded texture [minecraft:texture:panorama_2]
2020-12-28 13:37:34 DEBUG [litecraft::core::resource_manager::texture_manager] Uploading texture [minecraft:texture:panorama_1] to GPU
2020-12-28 13:37:34 DEBUG [litecraft::core::resource_manager::texture_manager] Loaded texture [minecraft:texture:panorama_1]
2020-12-28 13:37:34 DEBUG [litecraft::core::resource_manager::texture_manager] Uploading texture [minecraft:texture:panorama_5] to GPU
2020-12-28 13:37:34 DEBUG [litecraft::core::resource_manager::texture_manager] Loaded texture [minecraft:texture:panorama_5]
2020-12-28 13:37:34 INFO  [litecraft::scenes::loading] All resources are now loaded, opening main menu
2020-12-28 13:37:34 INFO  [litecraft::core::resource_manager::texture_manager] Loading texture '[minecraft:texture:minecraft]'.
2020-12-28 13:37:34 INFO  [litecraft::core::resource_manager::texture_manager] Loading texture '[minecraft:texture:widgets]'.
thread 'main' panicked at 'attempted to leave type `linked_hash_map::Node<u32, rusttype::gpu_cache::Row>` uninitialized, which is invalid', /rustc/d9a105fdd46c926ae606777a46dd90e5b838f92f/library/core/src/mem/mod.rs:659:9
stack backtrace:
   0: rust_begin_unwind
             at /rustc/d9a105fdd46c926ae606777a46dd90e5b838f92f/library/std/src/panicking.rs:493:5
   1: core::panicking::panic_fmt
             at /rustc/d9a105fdd46c926ae606777a46dd90e5b838f92f/library/core/src/panicking.rs:92:14
   2: core::panicking::panic
             at /rustc/d9a105fdd46c926ae606777a46dd90e5b838f92f/library/core/src/panicking.rs:50:5
   3: core::mem::uninitialized
             at /rustc/d9a105fdd46c926ae606777a46dd90e5b838f92f/library/core/src/mem/mod.rs:659:9
   4: linked_hash_map::LinkedHashMap<K,V,S>::ensure_guard_node
             at /Users/admin/.cargo/registry/src/github.com-1ecc6299db9ec823/linked-hash-map-0.5.1/src/lib.rs:174:52
   5: linked_hash_map::LinkedHashMap<K,V,S>::insert
             at /.cargo/registry/src/github.com-1ecc6299db9ec823/linked-hash-map-0.5.1/src/lib.rs:304:9
   6: rusttype::gpu_cache::Cache::cache_queued
             at /.cargo/registry/src/github.com-1ecc6299db9ec823/rusttype-0.5.2/src/gpu_cache.rs:667:17
   7: conrod::backend::glium::Renderer::fill
             at /.cargo/git/checkouts/conrod-179bd34c00f75633/9097df4/./src/backend/glium.rs:654:21
   8: litecraft::gfx::canvas::Canvas::start
             at ./src/gfx/canvas.rs:125:17
   9: litecraft::main
             at ./src/main.rs:71:5
  10: core::ops::function::FnOnce::call_once
             at /rustc/d9a105fdd46c926ae606777a46dd90e5b838f92f/library/core/src/ops/function.rs:227:5
```

**Closing issues 😉**

Fixes #21 
Fixes #23 
Fixes #28 